### PR TITLE
Allow fully offline use with data-uri

### DIFF
--- a/src/asciidoctor-emoji.js
+++ b/src/asciidoctor-emoji.js
@@ -20,8 +20,8 @@ function emojiInlineMacro () {
     }
     const emojiUnicode = twemojiMap[target]
     if (emojiUnicode) {
-      image_src = parent.getImageUri(`https://twemoji.maxcdn.com/2/svg/${emojiUnicode}.svg`)
-      return `<img class="emoji" draggable="false" height="${size}" width="${size}" src="${image_src}" />`
+      const imageSrc = parent.getImageUri(`https://twemoji.maxcdn.com/2/svg/${emojiUnicode}.svg`)
+      return `<img class="emoji" draggable="false" height="${size}" width="${size}" src="${imageSrc}" />`
     }
     console.warn(`Skipping emoji inline macro. ${target} not found`)
     return `[emoji ${target} not found]`

--- a/src/asciidoctor-emoji.js
+++ b/src/asciidoctor-emoji.js
@@ -20,7 +20,8 @@ function emojiInlineMacro () {
     }
     const emojiUnicode = twemojiMap[target]
     if (emojiUnicode) {
-      return `<img class="emoji" draggable="false" height="${size}" width="${size}" src="https://twemoji.maxcdn.com/2/svg/${emojiUnicode}.svg" />`
+      image_src = parent.getImageUri(`https://twemoji.maxcdn.com/2/svg/${emojiUnicode}.svg`)
+      return `<img class="emoji" draggable="false" height="${size}" width="${size}" src="${image_src}" />`
     }
     console.warn(`Skipping emoji inline macro. ${target} not found`)
     return `[emoji ${target} not found]`

--- a/test/test.js
+++ b/test/test.js
@@ -68,4 +68,12 @@ describe('Conversion', () => {
     const html = asciidoctor.convert(input, { extension_registry: registry })
     expect(html).to.contain('<img class="emoji" draggable="false" height="42px" width="42px" src="https://twemoji.maxcdn.com/2/svg/1f427.svg" />')
   })
+  it('should convert an existing emoji into an inline image', () => {
+    const input = 'emoji:black_circle[]'
+    const registry = asciidoctor.Extensions.create()
+    asciidoctorEmoji.register(registry)
+    const html = asciidoctor.convert(input, {extension_registry: registry , attributes: ['data-uri', 'allow-uri-read']})
+    expect(html).to.contain('<img class="emoji" draggable="false" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzNiAzNiI+PGNpcmNsZSBmaWxsPSIjMzEzNzNEIiBjeD0iMTgiIGN5PSIxOCIgcj0iMTgiLz48L3N2Zz4=" width="24px" height="24px">')
+  })
+
 })

--- a/test/test.js
+++ b/test/test.js
@@ -72,8 +72,7 @@ describe('Conversion', () => {
     const input = 'emoji:black_circle[]'
     const registry = asciidoctor.Extensions.create()
     asciidoctorEmoji.register(registry)
-    const html = asciidoctor.convert(input, {extension_registry: registry , attributes: ['data-uri', 'allow-uri-read']})
-    expect(html).to.contain('<img class="emoji" draggable="false" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzNiAzNiI+PGNpcmNsZSBmaWxsPSIjMzEzNzNEIiBjeD0iMTgiIGN5PSIxOCIgcj0iMTgiLz48L3N2Zz4=" width="24px" height="24px">')
+    const html = asciidoctor.convert(input, { extension_registry: registry, safe: 'safe', attributes: { 'data-uri': '', 'allow-uri-read': '' } })
+    expect(html).to.contain('<img class="emoji" draggable="false" height="24px" width="24px" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzNiAzNiI+PGNpcmNsZSBmaWxsPSIjMzEzNzNEIiBjeD0iMTgiIGN5PSIxOCIgcj0iMTgiLz48L3N2Zz4=" />')
   })
-
 })


### PR DESCRIPTION
This is a workaround for #10. This solution gives fully offline emojis with little additional code. When using one emoji multiple times this would increase the size of the overall result compared to a "download and cache" solution.