### PR TITLE
feat: add emoji/unresolved roles, log unresolved emoji via Asciidoctor's logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Require Node.js 20 or later
 - Regenerate `src/twemoji-map.js` from `emoji-datasource-twitter` (was hand-maintained from a stale, unmaintained `jollygoodcode/twemoji` YAML file); some emoji short names now resolve to a different, more current codepoint (e.g. `beetle` now points to the emoji introduced in Unicode 13.0, the previous one is available as `ladybug`)
 - Point emoji images at `@discordapp/twemoji` (Discord's actively maintained fork at [discord/twemoji](https://github.com/discord/twemoji), pinned to `16.0.1`) instead of the official `twemoji` npm package, which stopped publishing image assets after `12.0.2` and left `twemoji@latest` silently serving stale, years-old artwork missing every emoji added since Unicode 13
+- Resolved emoji now render with `class="image emoji"` (was `class="emoji"`); an unresolved emoji now renders as `<span class="emoji unresolved">emoji:name[] unresolved</span>` instead of `[emoji name not found]`, mirroring Antora's `xref unresolved` convention so both cases can be targeted with CSS
 
 ### Changed
 
@@ -15,6 +16,7 @@
 - Switch linting/formatting to Biome
 - Switch tests to Node's built-in test runner (`node:test` + `node:assert`)
 - Automate releases from GitHub Actions: bump the version, roll this changelog, tag, publish to npm and create the GitHub release from a `workflow_dispatch` input, including prerelease (`-alpha`/`-beta`/`-rc`) and maintenance-branch npm dist-tag handling
+- Log unresolved emoji through Asciidoctor's own logger (respecting a caller-supplied `logger` option and including the source line when the document is processed with `sourcemap: true`) instead of `console.warn`
 
 ## v0.5.0 (2023-09-04)
 

--- a/README.md
+++ b/README.md
@@ -104,10 +104,22 @@ You can also specify a size in pixel :tada:
 emoji:tada[42px]
 ```
 
+If the emoji does not exist, a warning is logged (through Asciidoctor's own logger, including
+the source line when the document is processed with `sourcemap: true`) and the macro is left
+in place, marked with the `unresolved` role so it can be styled or spotted in the output:
+
+```adoc
+emoji:not-an-emoji[]
+```
+
+```html
+<span class="emoji unresolved">emoji:not-an-emoji[] unresolved</span>
+```
+
 ## How ?
 
 This extension is using [Twemoji](https://github.com/discord/twemoji), Discord's actively maintained fork of Twitter's original emoji set.
-The `emoji` inline macro is converted into an `<image>` that points to a remote SVG:
+The `emoji` inline macro is converted into an `<image>` that points to a remote SVG, tagged with the `emoji` role so it can be targeted with CSS:
 
 
 ```adoc
@@ -115,8 +127,8 @@ emoji:beetle[]
 ```
 
 ```html
-<span class="emoji"><img src="https://cdn.jsdelivr.net/npm/@discordapp/twemoji@16.0.1/dist/svg/1fab2.svg" alt="beetle" width="24px" height="24px"></span>
+<span class="image emoji"><img src="https://cdn.jsdelivr.net/npm/@discordapp/twemoji@16.0.1/dist/svg/1fab2.svg" alt="beetle" width="24px" height="24px"></span>
 ```
 
-<span class="emoji"><img src="https://cdn.jsdelivr.net/npm/@discordapp/twemoji@16.0.1/dist/svg/1fab2.svg" alt="beetle" width="24px" height="24px"></span>
+<span class="image emoji"><img src="https://cdn.jsdelivr.net/npm/@discordapp/twemoji@16.0.1/dist/svg/1fab2.svg" alt="beetle" width="24px" height="24px"></span>
 

--- a/src/asciidoctor-emoji.js
+++ b/src/asciidoctor-emoji.js
@@ -24,16 +24,27 @@ function emojiInlineMacro() {
     if (emojiUnicode) {
       return this.createInline(parent, 'image', '', {
         target: `https://cdn.jsdelivr.net/npm/@discordapp/twemoji@16.0.1/dist/svg/${emojiUnicode}.svg`,
-        type: 'emoji',
         attributes: {
           alt: target,
           height: size,
           width: size,
+          role: 'emoji',
         },
       })
     }
-    console.warn(`Skipping emoji inline macro. ${target} not found`)
-    return this.createInline(parent, 'quoted', `[emoji ${target} not found]`, attrs)
+    const doc = parent.getDocument()
+    // Workaround: in @asciidoctor/core 4.0.4, doc.getLogger() ignores a per-call `logger` option
+    // passed to convert()/load() once outside load()'s internal async-local-storage scope (i.e.
+    // during doc.convert(), where this macro runs), while the `logger` property getter respects
+    // it correctly. Use `doc.logger` until that inconsistency is fixed upstream.
+    doc.logger.warn(
+      doc.messageWithContext(`skipping emoji inline macro, ${target} not found`, {
+        source_location: parent.getSourceLocation?.() ?? null,
+      }),
+    )
+    return this.createInline(parent, 'quoted', `emoji:${target}[] unresolved`, {
+      attributes: { role: 'emoji unresolved' },
+    })
   })
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { convert, Extensions } from '@asciidoctor/core'
+import { convert, Extensions, MemoryLogger } from '@asciidoctor/core'
 import { register } from '../src/asciidoctor-emoji.js'
 
 describe('Registration', () => {
@@ -34,7 +34,7 @@ describe('Conversion', () => {
       const html = await convert(input, { extension_registry: registry })
       assert.ok(
         html.includes(
-          '<span class="emoji"><img src="https://cdn.jsdelivr.net/npm/@discordapp/twemoji@16.0.1/dist/svg/1f604.svg" alt="smile" width="24px" height="24px"></span>',
+          '<span class="image emoji"><img src="https://cdn.jsdelivr.net/npm/@discordapp/twemoji@16.0.1/dist/svg/1f604.svg" alt="smile" width="24px" height="24px"></span>',
         ),
       )
     })
@@ -43,7 +43,24 @@ describe('Conversion', () => {
       const registry = Extensions.create()
       register(registry)
       const html = await convert(input, { extension_registry: registry })
-      assert.ok(html.includes('[emoji ooops not found]'))
+      assert.ok(html.includes('<span class="emoji unresolved">emoji:ooops[] unresolved</span>'))
+    })
+    it('should log a warning with the source location when the emoji does not exist', async () => {
+      const input = 'emoji:ooops[]'
+      const registry = Extensions.create()
+      register(registry)
+      const memoryLogger = MemoryLogger.create()
+      await convert(input, {
+        extension_registry: registry,
+        sourcemap: true,
+        logger: memoryLogger,
+        attributes: { docfile: 'test.adoc' },
+      })
+      const messages = memoryLogger.getMessages()
+      assert.equal(messages.length, 1)
+      assert.equal(messages[0].getSeverity(), 'WARN')
+      assert.equal(messages[0].getText(), 'skipping emoji inline macro, ooops not found')
+      assert.equal(messages[0].getSourceLocation().getLineNumber(), 1)
     })
   })
   it('should convert an existing emoji into an image with the size 2x (34px)', async () => {
@@ -53,7 +70,7 @@ describe('Conversion', () => {
     const html = await convert(input, { extension_registry: registry })
     assert.ok(
       html.includes(
-        '<span class="emoji"><img src="https://cdn.jsdelivr.net/npm/@discordapp/twemoji@16.0.1/dist/svg/1f385-1f3ff.svg" alt="santa-skin-tone-6" width="34px" height="34px"></span>',
+        '<span class="image emoji"><img src="https://cdn.jsdelivr.net/npm/@discordapp/twemoji@16.0.1/dist/svg/1f385-1f3ff.svg" alt="santa-skin-tone-6" width="34px" height="34px"></span>',
       ),
     )
   })
@@ -64,7 +81,7 @@ describe('Conversion', () => {
     const html = await convert(input, { extension_registry: registry })
     assert.ok(
       html.includes(
-        '<span class="emoji"><img src="https://cdn.jsdelivr.net/npm/@discordapp/twemoji@16.0.1/dist/svg/1fab2.svg" alt="beetle" width="68px" height="68px"></span>',
+        '<span class="image emoji"><img src="https://cdn.jsdelivr.net/npm/@discordapp/twemoji@16.0.1/dist/svg/1fab2.svg" alt="beetle" width="68px" height="68px"></span>',
       ),
     )
   })
@@ -75,7 +92,7 @@ describe('Conversion', () => {
     const html = await convert(input, { extension_registry: registry })
     assert.ok(
       html.includes(
-        '<span class="emoji"><img src="https://cdn.jsdelivr.net/npm/@discordapp/twemoji@16.0.1/dist/svg/1f427.svg" alt="penguin" width="42px" height="42px"></span>',
+        '<span class="image emoji"><img src="https://cdn.jsdelivr.net/npm/@discordapp/twemoji@16.0.1/dist/svg/1f427.svg" alt="penguin" width="42px" height="42px"></span>',
       ),
     )
   })
@@ -86,7 +103,7 @@ describe('Conversion', () => {
     const html = await convert(input, { extension_registry: registry })
     assert.ok(
       html.includes(
-        '<span class="emoji"><img src="https://cdn.jsdelivr.net/npm/@discordapp/twemoji@16.0.1/dist/svg/1f951.svg" alt="avocado" width="24px" height="24px"></span>',
+        '<span class="image emoji"><img src="https://cdn.jsdelivr.net/npm/@discordapp/twemoji@16.0.1/dist/svg/1f951.svg" alt="avocado" width="24px" height="24px"></span>',
       ),
     )
   })
@@ -111,7 +128,7 @@ describe('Conversion', () => {
     })
     assert.ok(
       html.includes(
-        '<span class="emoji"><img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzNiAzNiI+PGNpcmNsZSBmaWxsPSIjMzEzNzNEIiBjeD0iMTgiIGN5PSIxOCIgcj0iMTgiLz48L3N2Zz4=" alt="black_circle" width="24px" height="24px"></span>',
+        '<span class="image emoji"><img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzNiAzNiI+PGNpcmNsZSBmaWxsPSIjMzEzNzNEIiBjeD0iMTgiIGN5PSIxOCIgcj0iMTgiLz48L3N2Zz4=" alt="black_circle" width="24px" height="24px"></span>',
       ),
     )
   })


### PR DESCRIPTION
#### Summary

- Resolved emoji now render with `role="emoji"` (`class="image emoji"`, was `class="emoji"`), giving a stable CSS hook for styling all emoji images.
- Unresolved emoji now render as `<span class="emoji unresolved">emoji:name[] unresolved</span>` instead of `[emoji name not found]`, mirroring Antora's `xref unresolved` convention so broken references can be styled or spotted in the output.
- Replace `console.warn` with Asciidoctor's own logger (`doc.messageWithContext(...)`), including the source line when the document is processed with `sourcemap: true`.
- Use `doc.logger` rather than `doc.getLogger()` as a workaround for an `@asciidoctor/core` 4.0.4 inconsistency: `getLogger()` ignores a caller-supplied `logger` option once outside `load()`'s internal async-local-storage scope (i.e. during `doc.convert()`, where this macro runs), while the `logger` property getter respects it correctly. Worth reporting upstream separately.
