### PR TITLE
feat: add emoji-pattern attribute to configure the image CDN/URL template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Add an `emoji-pattern` document attribute to configure the image URL template, so any CDN or emoji set can be used instead of the bundled Twemoji default. Supports `{codepoint}`/`{CODEPOINT}`/`{codepoint_underscore}` (hyphen- or underscore-joined hex Unicode codepoint, lower or upper case) and `{emoji}` (percent-encoded emoji character) placeholders, covering CDNs such as the `emoji-datasource-*` packages on jsDelivr (Twitter, Facebook, Apple, Google sets), the official Twemoji CDN, OpenMoji, Google's Noto Emoji font, and [emoji-cdn](https://github.com/oddmario/emoji-cdn)
+
 ### Breaking Changes
 
 - Bump the `@asciidoctor/core` peer dependency to `>=4.0 <5.0` (native JS rewrite, async API)

--- a/README.md
+++ b/README.md
@@ -116,6 +116,42 @@ emoji:not-an-emoji[]
 <span class="emoji unresolved">emoji:not-an-emoji[] unresolved</span>
 ```
 
+## Configuring the image source
+
+By default, emoji are rendered from Discord's `@discordapp/twemoji` fork on jsDelivr (see [How ?](#how-) below).
+You can point at a different CDN or emoji set with the `emoji-pattern` document attribute, a URL template
+with a placeholder for the emoji:
+
+* `{codepoint}` — the hyphen-joined, lowercase hex Unicode codepoint(s), e.g. `1f604` or `1f1eb-1f1f7` for `flag-fr`
+* `{CODEPOINT}` — same, but uppercase, e.g. `1F1EB-1F1F7` for `flag-fr` (needed by, e.g., OpenMoji)
+* `{codepoint_underscore}` — same as `{codepoint}`, but underscore-joined, e.g. `1f1eb_1f1f7` for `flag-fr` (needed by, e.g., Google's Noto Emoji CDN)
+* `{emoji}` — the actual emoji character(s), percent-encoded, e.g. `%F0%9F%87%AB%F0%9F%87%B7` for `flag-fr`
+
+```adoc
+:emoji-pattern: https://cdn.jsdelivr.net/npm/emoji-datasource-twitter@16.0.0/img/twitter/64/{codepoint}.png
+
+emoji:tada[]
+```
+
+Other examples:
+
+```adoc
+// Facebook emoji set, served from jsDelivr
+:emoji-pattern: https://cdn.jsdelivr.net/npm/emoji-datasource-facebook@16.0.0/img/facebook/64/{codepoint}.png
+
+// Official Twemoji CDN
+:emoji-pattern: https://twemoji.maxcdn.com/2/svg/{codepoint}.svg
+
+// OpenMoji, served from jsDelivr (requires uppercase codepoints)
+:emoji-pattern: https://cdn.jsdelivr.net/npm/openmoji@16.0.0/color/svg/{CODEPOINT}.svg
+
+// Google's Noto Emoji font, served by Google Fonts (requires underscore-joined codepoints)
+:emoji-pattern: https://fonts.gstatic.com/s/e/notoemoji/latest/{codepoint_underscore}/512.png
+
+// emoji-cdn (https://github.com/oddmario/emoji-cdn), keyed by the raw emoji character
+:emoji-pattern: https://emoji-cdn.mqrio.dev/{emoji}?style=google
+```
+
 ## How ?
 
 This extension is using [Twemoji](https://github.com/discord/twemoji), Discord's actively maintained fork of Twitter's original emoji set.

--- a/src/asciidoctor-emoji.js
+++ b/src/asciidoctor-emoji.js
@@ -1,11 +1,22 @@
 import twemojiMap from './twemoji-map.js'
 
+// Converts a hyphen-joined hex codepoint sequence (e.g. '1f9d1-200d-1f3a8') into the
+// actual emoji character(s) it represents, for CDNs that key images by the raw emoji
+// (e.g. https://emoji-cdn.mqrio.dev/%F0%9F%8E%89?style=google) instead of its codepoint.
+function codepointToChar(codepoint) {
+  return codepoint
+    .split('-')
+    .map((cp) => String.fromCodePoint(Number.parseInt(cp, 16)))
+    .join('')
+}
+
 function emojiInlineMacro() {
   this.named('emoji')
   this.positionalAttributes('size')
 
   const defaultSize = '24px'
   const sizeMap = { '1x': '17px', lg: defaultSize, '2x': '34px', '3x': '50px', '4x': '68px', '5x': '85px' }
+  const defaultPattern = 'https://cdn.jsdelivr.net/npm/@discordapp/twemoji@16.0.1/dist/svg/{codepoint}.svg'
 
   this.process((parent, target, attrs) => {
     // @asciidoctor/core's inline macro substitution doesn't honor positionalAttributes()
@@ -20,10 +31,17 @@ function emojiInlineMacro() {
     } else {
       size = defaultSize
     }
+    const doc = parent.getDocument()
     const emojiUnicode = twemojiMap[target]
     if (emojiUnicode) {
+      const pattern = doc.getAttribute('emoji-pattern', defaultPattern)
+      const url = pattern
+        .replaceAll('{codepoint}', emojiUnicode)
+        .replaceAll('{CODEPOINT}', emojiUnicode.toUpperCase())
+        .replaceAll('{codepoint_underscore}', emojiUnicode.replaceAll('-', '_'))
+        .replaceAll('{emoji}', encodeURIComponent(codepointToChar(emojiUnicode)))
       return this.createInline(parent, 'image', '', {
-        target: `https://cdn.jsdelivr.net/npm/@discordapp/twemoji@16.0.1/dist/svg/${emojiUnicode}.svg`,
+        target: url,
         attributes: {
           alt: target,
           height: size,
@@ -32,7 +50,6 @@ function emojiInlineMacro() {
         },
       })
     }
-    const doc = parent.getDocument()
     // Workaround: in @asciidoctor/core 4.0.4, doc.getLogger() ignores a per-call `logger` option
     // passed to convert()/load() once outside load()'s internal async-local-storage scope (i.e.
     // during doc.convert(), where this macro runs), while the `logger` property getter respects

--- a/test/test.js
+++ b/test/test.js
@@ -117,6 +117,79 @@ describe('Conversion', () => {
     assert.ok(primary.includes('src="https://cdn.jsdelivr.net/npm/@discordapp/twemoji@16.0.1/dist/svg/1f44d.svg"'))
     assert.ok(alias.includes('src="https://cdn.jsdelivr.net/npm/@discordapp/twemoji@16.0.1/dist/svg/1f44d.svg"'))
   })
+  it('should use the emoji-pattern attribute with a {codepoint} placeholder', async () => {
+    const input = 'emoji:beetle[]'
+    const registry = Extensions.create()
+    register(registry)
+    const html = await convert(input, {
+      extension_registry: registry,
+      attributes: {
+        'emoji-pattern':
+          'https://cdn.jsdelivr.net/npm/emoji-datasource-facebook@16.0.0/img/facebook/64/{codepoint}.png',
+      },
+    })
+    assert.ok(
+      html.includes(
+        '<span class="image emoji"><img src="https://cdn.jsdelivr.net/npm/emoji-datasource-facebook@16.0.0/img/facebook/64/1fab2.png" alt="beetle" width="24px" height="24px"></span>',
+      ),
+    )
+  })
+  it('should use the emoji-pattern attribute with an {emoji} placeholder', async () => {
+    const input = 'emoji:tada[]'
+    const registry = Extensions.create()
+    register(registry)
+    const html = await convert(input, {
+      extension_registry: registry,
+      attributes: { 'emoji-pattern': 'https://emoji-cdn.mqrio.dev/{emoji}?style=google' },
+    })
+    assert.ok(
+      html.includes(
+        '<span class="image emoji"><img src="https://emoji-cdn.mqrio.dev/%F0%9F%8E%89?style=google" alt="tada" width="24px" height="24px"></span>',
+      ),
+    )
+  })
+  it('should use the emoji-pattern attribute with a {CODEPOINT} placeholder', async () => {
+    const input = 'emoji:family_adult_child[]'
+    const registry = Extensions.create()
+    register(registry)
+    const html = await convert(input, {
+      extension_registry: registry,
+      attributes: { 'emoji-pattern': 'https://cdn.jsdelivr.net/npm/openmoji@16.0.0/color/svg/{CODEPOINT}.svg' },
+    })
+    assert.ok(
+      html.includes(
+        '<span class="image emoji"><img src="https://cdn.jsdelivr.net/npm/openmoji@16.0.0/color/svg/1F9D1-200D-1F9D2.svg" alt="family_adult_child" width="24px" height="24px"></span>',
+      ),
+    )
+  })
+  it('should use the emoji-pattern attribute with a {codepoint_underscore} placeholder', async () => {
+    const input = 'emoji:flag-fr[]'
+    const registry = Extensions.create()
+    register(registry)
+    const html = await convert(input, {
+      extension_registry: registry,
+      attributes: { 'emoji-pattern': 'https://fonts.gstatic.com/s/e/notoemoji/latest/{codepoint_underscore}/512.png' },
+    })
+    assert.ok(
+      html.includes(
+        '<span class="image emoji"><img src="https://fonts.gstatic.com/s/e/notoemoji/latest/1f1eb_1f1f7/512.png" alt="flag-fr" width="24px" height="24px"></span>',
+      ),
+    )
+  })
+  it('should resolve a multi-codepoint emoji to its {emoji} placeholder', async () => {
+    const input = 'emoji:flag-fr[]'
+    const registry = Extensions.create()
+    register(registry)
+    const html = await convert(input, {
+      extension_registry: registry,
+      attributes: { 'emoji-pattern': 'https://emoji-cdn.mqrio.dev/{emoji}?style=google' },
+    })
+    assert.ok(
+      html.includes(
+        '<span class="image emoji"><img src="https://emoji-cdn.mqrio.dev/%F0%9F%87%AB%F0%9F%87%B7?style=google" alt="flag-fr" width="24px" height="24px"></span>',
+      ),
+    )
+  })
   it('should convert an existing emoji into an inline image', async () => {
     const input = 'emoji:black_circle[]'
     const registry = Extensions.create()


### PR DESCRIPTION
Adds an `emoji-pattern` document attribute so the image source can be pointed at any CDN or emoji set instead of the bundled Twemoji default.

The pattern is a URL template supporting four placeholders:
- `{codepoint}` — lowercase, hyphen-joined hex codepoint(s) (e.g. `1f1eb-1f1f7`)
- `{CODEPOINT}` — same, uppercase (needed by OpenMoji)
- `{codepoint_underscore}` — same, underscore-joined (needed by Google's Noto Emoji CDN)
- `{emoji}` — the actual emoji character(s), percent-encoded (needed by CDNs like emoji-cdn.mqrio.dev)

Verified against real requests to jsDelivr's `emoji-datasource-*` packages (Twitter/Facebook/Apple/Google sets), the official Twemoji CDN, OpenMoji, Google's Noto Emoji font, and https://github.com/oddmario/emoji-cdn.
