### PR TITLE
feat: add emojis/emoji-webfont attributes to render emoji as text with a font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - Add an `emoji-pattern` document attribute to configure the image URL template, so any CDN or emoji set can be used instead of the bundled Twemoji default. Supports `{codepoint}`/`{CODEPOINT}`/`{codepoint_underscore}` (hyphen- or underscore-joined hex Unicode codepoint, lower or upper case) and `{emoji}` (percent-encoded emoji character) placeholders, covering CDNs such as the `emoji-datasource-*` packages on jsDelivr (Twitter, Facebook, Apple, Google sets), the official Twemoji CDN, OpenMoji, Google's Noto Emoji font, and [emoji-cdn](https://github.com/oddmario/emoji-cdn)
+- Add an `emojis: font` document attribute, mirroring Asciidoctor's own `icons: font`, that renders the actual Unicode emoji character (e.g. `<span class="emoji" title="heart" style="font-size:24px">❤</span>`) instead of an image, relying on the font available to the reader instead of fetching artwork from a CDN
+- Add an `emoji-webfont` document attribute that, when `emojis: font` is set, injects a `<link rel="stylesheet">` for the given URL into the `<head>` of a standalone document, for pointing at a webfont (e.g. Twemoji Mozilla, Noto Color Emoji) for consistent cross-platform rendering; opt-in only, no webfont is loaded by default
 
 ### Breaking Changes
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,48 @@ Other examples:
 :emoji-pattern: https://emoji-cdn.mqrio.dev/{emoji}?style=google
 ```
 
+## Rendering emoji as text with a font
+
+Instead of fetching an image, you can render the emoji as its actual Unicode character and let
+the font handle the display (e.g. a system emoji font, or a webfont like Noto Emoji/Twemoji
+Mozilla loaded via CSS) by setting the `emojis` document attribute to `font`:
+
+```adoc
+:emojis: font
+
+I emoji:heart[] Asciidoctor.js!
+```
+
+```html
+I <span class="emoji" title="heart" style="font-size:24px">❤</span> Asciidoctor.js!
+```
+
+The `size` argument (see above) is applied as a `font-size` instead of `width`/`height`. An
+unresolved emoji still logs a warning and renders the same `unresolved`-tagged placeholder
+regardless of the `emojis` attribute.
+
+By default, `emojis: font` relies on whatever emoji font is already available to the reader
+(the OS/browser's system emoji font). No webfont is bundled or loaded automatically, so there's
+no extra network request. If you want consistent rendering across platforms, point the
+`emoji-webfont` document attribute at a stylesheet (typically one that declares an `@font-face`,
+e.g. [Twemoji Mozilla](https://github.com/mozilla/twemoji-colr) or
+[Noto Color Emoji](https://fonts.google.com/noto/specimen/Noto+Color+Emoji)) and it is injected
+as a `<link>` in the document `<head>`:
+
+```adoc
+:emojis: font
+:emoji-webfont: https://example.org/twemoji-mozilla.css
+
+I emoji:heart[] Asciidoctor.js!
+```
+
+```html
+<link rel="stylesheet" href="https://example.org/twemoji-mozilla.css">
+```
+
+`emoji-webfont` only has an effect when `emojis` is set to `font`, and only when converting a
+standalone document (it has nowhere to inject a `<link>` in an embedded fragment).
+
 ## How ?
 
 This extension is using [Twemoji](https://github.com/discord/twemoji), Discord's actively maintained fork of Twitter's original emoji set.

--- a/src/asciidoctor-emoji.js
+++ b/src/asciidoctor-emoji.js
@@ -10,6 +10,11 @@ function codepointToChar(codepoint) {
     .join('')
 }
 
+const htmlEscapeMap = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }
+function escapeHtmlAttribute(str) {
+  return str.replace(/[&<>"]/g, (ch) => htmlEscapeMap[ch])
+}
+
 function emojiInlineMacro() {
   this.named('emoji')
   this.positionalAttributes('size')
@@ -34,6 +39,14 @@ function emojiInlineMacro() {
     const doc = parent.getDocument()
     const emojiUnicode = twemojiMap[target]
     if (emojiUnicode) {
+      if (doc.getAttribute('emojis') === 'font') {
+        const char = codepointToChar(emojiUnicode)
+        return this.createInline(
+          parent,
+          'quoted',
+          `<span class="emoji" title="${escapeHtmlAttribute(target)}" style="font-size:${size}">${char}</span>`,
+        )
+      }
       const pattern = doc.getAttribute('emoji-pattern', defaultPattern)
       const url = pattern
         .replaceAll('{codepoint}', emojiUnicode)
@@ -65,13 +78,24 @@ function emojiInlineMacro() {
   })
 }
 
+function emojiWebfontDocinfoProcessor() {
+  this.process((doc) => {
+    if (doc.getAttribute('emojis') !== 'font') return ''
+    const webfont = doc.getAttribute('emoji-webfont')
+    if (!webfont) return ''
+    return `<link rel="stylesheet" href="${escapeHtmlAttribute(webfont)}">`
+  })
+}
+
 export function register(registry) {
   if (typeof registry.register === 'function') {
     registry.register(function () {
       this.inlineMacro(emojiInlineMacro)
+      this.docinfoProcessor(emojiWebfontDocinfoProcessor)
     })
   } else if (typeof registry.block === 'function') {
     registry.inlineMacro(emojiInlineMacro)
+    registry.docinfoProcessor(emojiWebfontDocinfoProcessor)
   }
   return registry
 }

--- a/test/test.js
+++ b/test/test.js
@@ -10,6 +10,7 @@ describe('Registration', () => {
     register(registry)
     assert.equal(registry.hasInlineMacros(), true)
     assert.ok(registry.registeredForInlineMacro('emoji'))
+    assert.equal(registry.hasDocinfoProcessors(), true)
   })
 })
 
@@ -189,6 +190,89 @@ describe('Conversion', () => {
         '<span class="image emoji"><img src="https://emoji-cdn.mqrio.dev/%F0%9F%87%AB%F0%9F%87%B7?style=google" alt="flag-fr" width="24px" height="24px"></span>',
       ),
     )
+  })
+  it('should render the emoji as a unicode character when the emojis attribute is font', async () => {
+    const input = 'emoji:smile[]'
+    const registry = Extensions.create()
+    register(registry)
+    const html = await convert(input, {
+      extension_registry: registry,
+      attributes: { emojis: 'font' },
+    })
+    assert.ok(html.includes('<span class="emoji" title="smile" style="font-size:24px">😄</span>'))
+  })
+  it('should honor the size attribute as a font-size when the emojis attribute is font', async () => {
+    const input = 'emoji:tada[2x]'
+    const registry = Extensions.create()
+    register(registry)
+    const html = await convert(input, {
+      extension_registry: registry,
+      attributes: { emojis: 'font' },
+    })
+    assert.ok(html.includes('<span class="emoji" title="tada" style="font-size:34px">🎉</span>'))
+  })
+  it('should render a multi-codepoint emoji as its unicode character(s) when the emojis attribute is font', async () => {
+    const input = 'emoji:flag-fr[]'
+    const registry = Extensions.create()
+    register(registry)
+    const html = await convert(input, {
+      extension_registry: registry,
+      attributes: { emojis: 'font' },
+    })
+    assert.ok(html.includes('<span class="emoji" title="flag-fr" style="font-size:24px">🇫🇷</span>'))
+  })
+  it('should render an emoji alias as its own name in the title attribute when the emojis attribute is font', async () => {
+    const input = 'emoji:+1[]'
+    const registry = Extensions.create()
+    register(registry)
+    const html = await convert(input, {
+      extension_registry: registry,
+      attributes: { emojis: 'font' },
+    })
+    assert.ok(html.includes('<span class="emoji" title="+1" style="font-size:24px">👍</span>'))
+  })
+  it('should still report an unresolved emoji as unresolved when the emojis attribute is font', async () => {
+    const input = 'emoji:ooops[]'
+    const registry = Extensions.create()
+    register(registry)
+    const html = await convert(input, {
+      extension_registry: registry,
+      attributes: { emojis: 'font' },
+    })
+    assert.ok(html.includes('<span class="emoji unresolved">emoji:ooops[] unresolved</span>'))
+  })
+  it('should inject the emoji-webfont stylesheet in the head when the emojis attribute is font', async () => {
+    const input = 'emoji:smile[]'
+    const registry = Extensions.create()
+    register(registry)
+    const html = await convert(input, {
+      extension_registry: registry,
+      standalone: true,
+      attributes: { emojis: 'font', 'emoji-webfont': 'https://example.org/emoji-font.css' },
+    })
+    assert.ok(html.includes('<link rel="stylesheet" href="https://example.org/emoji-font.css">'))
+  })
+  it('should not inject any stylesheet when emoji-webfont is not set', async () => {
+    const input = 'emoji:smile[]'
+    const registry = Extensions.create()
+    register(registry)
+    const html = await convert(input, {
+      extension_registry: registry,
+      standalone: true,
+      attributes: { emojis: 'font' },
+    })
+    assert.ok(!html.includes('emoji-font'))
+  })
+  it('should not inject the emoji-webfont stylesheet when the emojis attribute is not font', async () => {
+    const input = 'emoji:smile[]'
+    const registry = Extensions.create()
+    register(registry)
+    const html = await convert(input, {
+      extension_registry: registry,
+      standalone: true,
+      attributes: { 'emoji-webfont': 'https://example.org/emoji-font.css' },
+    })
+    assert.ok(!html.includes('example.org'))
   })
   it('should convert an existing emoji into an inline image', async () => {
     const input = 'emoji:black_circle[]'


### PR DESCRIPTION
Adds an `emojis: font` document attribute (mirroring Asciidoctor's own `icons: font`) that renders the actual Unicode emoji character instead of fetching an image, e.g.:

```html
<span class="emoji" title="heart" style="font-size:24px">❤</span>
```

relying on whatever emoji font is already available to the reader (system font) rather than a CDN. The existing `size` argument on `emoji:` is applied as `font-size` instead of `width`/`height` in this mode.

Also adds an opt-in `emoji-webfont` document attribute: when set alongside `emojis: font`, a docinfo processor injects a `<link rel="stylesheet">` for the given URL into the `<head>` of a standalone document, so callers can point at a webfont (e.g. Twemoji Mozilla, Noto Color Emoji) for consistent cross-platform rendering. No webfont is bundled or loaded by default.
