### PR TITLE
chore: measure test coverage, drop dead pre-4.0 registration fallback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,3 +34,13 @@ jobs:
         run: npm run build
       - name: Test
         run: npm test
+      - name: Coverage summary
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == 24
+        run: |
+          {
+            echo '### Coverage'
+            echo
+            echo '```'
+            npm run test:coverage 2>&1 | sed -n '/start of coverage report/,/end of coverage report/p'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Add an `emoji-pattern` document attribute to configure the image URL template, so any CDN or emoji set can be used instead of the bundled Twemoji default. Supports `{codepoint}`/`{CODEPOINT}`/`{codepoint_underscore}` (hyphen- or underscore-joined hex Unicode codepoint, lower or upper case) and `{emoji}` (percent-encoded emoji character) placeholders, covering CDNs such as the `emoji-datasource-*` packages on jsDelivr (Twitter, Facebook, Apple, Google sets), the official Twemoji CDN, OpenMoji, Google's Noto Emoji font, and [emoji-cdn](https://github.com/oddmario/emoji-cdn)
 - Add an `emojis: font` document attribute, mirroring Asciidoctor's own `icons: font`, that renders the actual Unicode emoji character (e.g. `<span class="emoji" title="heart" style="font-size:24px">❤</span>`) instead of an image, relying on the font available to the reader instead of fetching artwork from a CDN
 - Add an `emoji-webfont` document attribute that, when `emojis: font` is set, injects a `<link rel="stylesheet">` for the given URL into the `<head>` of a standalone document, for pointing at a webfont (e.g. Twemoji Mozilla, Noto Color Emoji) for consistent cross-platform rendering; opt-in only, no webfont is loaded by default
+- Add a `test:coverage` script (`node --test --experimental-test-coverage`) to report test coverage using Node's built-in test runner
+- Publish the coverage report to the GitHub Actions job summary (visible from a PR's checks) on the `ubuntu-latest`/Node 24 build leg
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Regenerate `src/twemoji-map.js` from `emoji-datasource` (was hand-maintained from a stale, unmaintained `jollygoodcode/twemoji` YAML file); some emoji short names now resolve to a different, more current codepoint (e.g. `beetle` now points to the emoji introduced in Unicode 13.0, the previous one is available as `ladybug`)
 - Point emoji images at `@discordapp/twemoji` (Discord's actively maintained fork at [discord/twemoji](https://github.com/discord/twemoji), pinned to `16.0.1`) instead of the official `twemoji` npm package, which stopped publishing image assets after `12.0.2` and left `twemoji@latest` silently serving stale, years-old artwork missing every emoji added since Unicode 13
 - Resolved emoji now render with `class="image emoji"` (was `class="emoji"`); an unresolved emoji now renders as `<span class="emoji unresolved">emoji:name[] unresolved</span>` instead of `[emoji name not found]`, mirroring Antora's `xref unresolved` convention so both cases can be targeted with CSS
+- Drop the fallback to the pre-4.0 `registry.register(fn)` DSL for registering extensions; `register()` now always calls `registry.inlineMacro()`/`registry.docinfoProcessor()` directly, which is the only shape `@asciidoctor/core` 4.x's `Registry` supports
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "test": "node --test",
+    "test:coverage": "node --test --experimental-test-coverage",
     "lint": "biome check .",
     "format": "biome format --write .",
     "build": "rollup -c",

--- a/src/asciidoctor-emoji.js
+++ b/src/asciidoctor-emoji.js
@@ -88,14 +88,7 @@ function emojiWebfontDocinfoProcessor() {
 }
 
 export function register(registry) {
-  if (typeof registry.register === 'function') {
-    registry.register(function () {
-      this.inlineMacro(emojiInlineMacro)
-      this.docinfoProcessor(emojiWebfontDocinfoProcessor)
-    })
-  } else if (typeof registry.block === 'function') {
-    registry.inlineMacro(emojiInlineMacro)
-    registry.docinfoProcessor(emojiWebfontDocinfoProcessor)
-  }
+  registry.inlineMacro(emojiInlineMacro)
+  registry.docinfoProcessor(emojiWebfontDocinfoProcessor)
   return registry
 }


### PR DESCRIPTION
`register()` had a branch checking `typeof registry.register === 'function'`, a fallback for a pre-4.0 `@asciidoctor/core` API. `@asciidoctor/core` 4.x's `Registry` never exposes an instance `.register()` (only the static `Extensions.register` for global groups), so that branch was unreachable dead code — always falling through to the `.inlineMacro()`/`.docinfoProcessor()` calls. Removed it now that the peer dependency is pinned to `>=4.0 <5.0`.

While looking into why coverage wasn't 100%, added a `test:coverage` script (`node --test --experimental-test-coverage`, Node's built-in reporter, no extra dependency) and wired it into the `ubuntu-latest`/Node 24 build leg to publish the coverage table to the GitHub Actions job summary, visible from a PR's checks.
