### PR TITLE
ci: publish to npm via Trusted Publishing instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,8 +77,6 @@ jobs:
       - name: Build
         run: npm run build
       - name: Publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --tag ${{ needs.tag.outputs.npm_tag }}
 
   release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Switch linting/formatting to Biome
 - Switch tests to Node's built-in test runner (`node:test` + `node:assert`)
 - Automate releases from GitHub Actions: bump the version, roll this changelog, tag, publish to npm and create the GitHub release from a `workflow_dispatch` input, including prerelease (`-alpha`/`-beta`/`-rc`) and maintenance-branch npm dist-tag handling
+- Publish to npm using [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (OIDC) instead of a long-lived `NPM_TOKEN` secret
 - Log unresolved emoji through Asciidoctor's own logger (respecting a caller-supplied `logger` option and including the source line when the document is processed with `sourcemap: true`) instead of `console.warn`
 - Document `emoji-pattern` with a side-by-side rendering of `emoji:grinning[]` across the Twitter, Facebook, and Google emoji sets, plus an animated Noto GIF via [emoji-cdn](https://github.com/oddmario/emoji-cdn)'s `animated-noto-color-emoji` style, to show how much a single attribute changes the artwork
 - Swap the `beetle` example in the "How ?" section for `ladybug`


### PR DESCRIPTION
The publish job already had `id-token: write` permission set, so this drops the `NODE_AUTH_TOKEN`/`NPM_TOKEN` secret from the `npm publish` step and lets npm's OIDC-based Trusted Publishing handle authentication, now that it's enabled for this package on npmjs. Node 24's bundled npm (11.16.x) already satisfies the >=11.5.1 requirement, so no runtime bump is needed.
